### PR TITLE
Make BGP controller crash when failing to sync existing services on s…

### DIFF
--- a/operator/cmd/root.go
+++ b/operator/cmd/root.go
@@ -471,7 +471,7 @@ func kvstoreEnabled() bool {
 
 var legacyCell = cell.Invoke(registerLegacyOnLeader)
 
-func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, factory store.Factory, svcResolver *dial.ServiceResolver) {
+func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, resources operatorK8s.Resources, factory store.Factory, svcResolver *dial.ServiceResolver, shutdowner hive.Shutdowner) {
 	ctx, cancel := context.WithCancel(context.Background())
 	legacy := &legacyOnLeader{
 		ctx:          ctx,
@@ -480,6 +480,7 @@ func registerLegacyOnLeader(lc cell.Lifecycle, clientset k8sClient.Clientset, re
 		resources:    resources,
 		storeFactory: factory,
 		svcResolver:  svcResolver,
+		shutdowner:   shutdowner,
 	}
 	lc.Append(cell.Hook{
 		OnStart: legacy.onStart,
@@ -495,6 +496,7 @@ type legacyOnLeader struct {
 	resources    operatorK8s.Resources
 	storeFactory store.Factory
 	svcResolver  *dial.ServiceResolver
+	shutdowner   hive.Shutdowner
 }
 
 func (legacy *legacyOnLeader) onStop(_ cell.HookContext) error {
@@ -567,7 +569,7 @@ func (legacy *legacyOnLeader) onStart(_ cell.HookContext) error {
 
 	if operatorOption.Config.BGPAnnounceLBIP {
 		log.Info("Starting LB IP allocator")
-		operatorWatchers.StartBGPBetaLBIPAllocator(legacy.ctx, legacy.clientset, legacy.resources.Services)
+		operatorWatchers.StartBGPBetaLBIPAllocator(legacy.ctx, legacy.clientset, legacy.resources.Services, legacy.shutdowner)
 	}
 
 	if kvstoreEnabled() {

--- a/operator/watchers/bgp.go
+++ b/operator/watchers/bgp.go
@@ -7,6 +7,7 @@ import (
 	"context"
 
 	"github.com/cilium/cilium/pkg/bgp/manager"
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
 	"github.com/cilium/cilium/pkg/k8s/resource"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
@@ -15,14 +16,14 @@ import (
 // StartBGPBetaLBIPAllocator starts the service watcher if it hasn't already and looks
 // for service of type LoadBalancer. Once it finds a service of that type, it
 // will try to allocate an external IP (LoadBalancerIP) for it.
-func StartBGPBetaLBIPAllocator(ctx context.Context, clientset client.Clientset, services resource.Resource[*slim_corev1.Service]) {
+func StartBGPBetaLBIPAllocator(ctx context.Context, clientset client.Clientset, services resource.Resource[*slim_corev1.Service], shutdowner hive.Shutdowner) {
 	go func() {
 		store, err := services.Store(ctx)
 		if err != nil {
 			log.WithError(err).Fatal("Failed to retrieve service store")
 		}
 
-		m, err := manager.New(ctx, clientset, store.CacheStore())
+		m, err := manager.New(ctx, clientset, store.CacheStore(), shutdowner)
 		if err != nil {
 			log.WithError(err).Fatal("Error creating BGP manager")
 		}

--- a/pkg/bgp/manager/manager.go
+++ b/pkg/bgp/manager/manager.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
+	"github.com/cilium/cilium/pkg/hive"
 	"github.com/cilium/cilium/pkg/k8s/client"
 )
 
@@ -19,7 +20,7 @@ import (
 // controller, which contains the allocator.
 //
 // New requires access to a cache.Store associated with the service watcher.
-func New(ctx context.Context, clientset client.Clientset, indexer cache.Store) (*Manager, error) {
+func New(ctx context.Context, clientset client.Clientset, indexer cache.Store, shutdowner hive.Shutdowner) (*Manager, error) {
 	ctrl, err := newMetalLBController(ctx, clientset)
 	if err != nil {
 		return nil, err
@@ -30,6 +31,8 @@ func New(ctx context.Context, clientset client.Clientset, indexer cache.Store) (
 		queue: workqueue.New(),
 
 		indexer: indexer,
+
+		shutdowner: shutdowner,
 	}
 
 	go func() {
@@ -62,6 +65,8 @@ type Manager struct {
 	// by the watcher. This is used in order to handle delete events. See
 	// comment inside (*Manager).run().
 	indexer cache.Store
+
+	shutdowner hive.Shutdowner
 }
 
 func (m *Manager) MarkSynced() {

--- a/pkg/bgp/manager/subscriber.go
+++ b/pkg/bgp/manager/subscriber.go
@@ -6,6 +6,7 @@
 package manager
 
 import (
+	"errors"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -18,6 +19,7 @@ import (
 	"github.com/cilium/cilium/pkg/k8s"
 	slim_corev1 "github.com/cilium/cilium/pkg/k8s/slim/k8s/api/core/v1"
 	"github.com/cilium/cilium/pkg/logging/logfields"
+	"github.com/cilium/hive"
 )
 
 // OnAddService handles an add event for services. It implements
@@ -153,6 +155,9 @@ func (m *Manager) beforeRun() {
 		for _, k := range retryKeys {
 			l.WithField("service", k).Warn("over 60 retries, giving up reconciliation")
 		}
+		// This is a fatal error as the BGP manager must synchronize existing services before proceeding.
+		m.shutdowner.Shutdown(hive.ShutdownWithError(errors.New("failed to reconcile some services on BGP manager startup")))
+		return
 	}
 
 	l.Info("finished beforeRun")


### PR DESCRIPTION
This PR fixes to panic cilium-operator when the BGP controller fails to synchronize existing all services on start-up.