### PR TITLE
Add force-identity-policy-updates flag to control policy regeneration on identity changes

### DIFF
--- a/daemon/cmd/daemon_main.go
+++ b/daemon/cmd/daemon_main.go
@@ -887,6 +887,9 @@ func InitGlobalFlags(cmd *cobra.Command, vp *viper.Viper) {
 	flags.Bool(option.PolicyAccountingArg, true, "Enable policy accounting")
 	option.BindEnv(vp, option.PolicyAccountingArg)
 
+	flags.Bool(option.ForceIdentityPolicyUpdates, true, "Force policy regeneration when identities are updated")
+	option.BindEnv(vp, option.ForceIdentityPolicyUpdates)
+
 	flags.Bool(option.EnableHubble, false, "Enable hubble server")
 	option.BindEnv(vp, option.EnableHubble)
 

--- a/daemon/cmd/policy.go
+++ b/daemon/cmd/policy.go
@@ -192,7 +192,7 @@ func (iao *identityAllocatorOwner) UpdateIdentities(added, deleted identity.Iden
 	iao.policy.GetSelectorCache().UpdateIdentities(added, deleted, wg)
 	// Wait for update propagation to endpoints before triggering policy updates
 	wg.Wait()
-	iao.policyUpdater.TriggerPolicyUpdates(false, "one or more identities created or deleted")
+	iao.policyUpdater.TriggerPolicyUpdates(option.Config.ForceIdentityPolicyUpdates, "one or more identities created or deleted")
 }
 
 // GetNodeSuffix returns the suffix to be appended to kvstore keys of this

--- a/pkg/option/config.go
+++ b/pkg/option/config.go
@@ -943,6 +943,10 @@ const (
 	// PolicyAccountingArg argument enable policy accounting.
 	PolicyAccountingArg = "policy-accounting"
 
+	// ForceIdentityPolicyUpdates forces policy regeneration when identities are updated.
+	// When true, policy updates are forced even when revision check would skip them.
+	ForceIdentityPolicyUpdates = "force-identity-policy-updates"
+
 	// EnableHubble enables hubble in the agent.
 	EnableHubble = "enable-hubble"
 
@@ -2096,6 +2100,10 @@ type DaemonConfig struct {
 	// PolicyAccounting enable policy accounting
 	PolicyAccounting bool
 
+	// ForceIdentityPolicyUpdates forces policy regeneration when identities are updated.
+	// When true, policy updates are forced even when revision check would skip them.
+	ForceIdentityPolicyUpdates bool
+
 	// EnableHubble specifies whether to enable the hubble server.
 	EnableHubble bool
 
@@ -3133,6 +3141,7 @@ func (c *DaemonConfig) Populate(vp *viper.Viper) {
 	c.CTMapEntriesTimeoutFIN = vp.GetDuration(CTMapEntriesTimeoutFINName)
 	c.PolicyAuditMode = vp.GetBool(PolicyAuditModeArg)
 	c.PolicyAccounting = vp.GetBool(PolicyAccountingArg)
+	c.ForceIdentityPolicyUpdates = vp.GetBool(ForceIdentityPolicyUpdates)
 	c.EnableIPv4FragmentsTracking = vp.GetBool(EnableIPv4FragmentsTrackingName)
 	c.FragmentsMapEntries = vp.GetInt(FragmentsMapEntriesName)
 	c.CRDWaitTimeout = vp.GetDuration(CRDWaitTimeout)


### PR DESCRIPTION
A rare race condition was discovered where the L4Policy calculation triggered by Endpoint creation completes before the IdentityWatcher registers the new Identity to the identitySelector. When this occurs, the Endpoint does not have the appropriate policy attached, and this state persists unless policies are updated.

This PR add an option to force a policy update when IdentityWatcher's UpdateIdentities is triggered. Setting this to true will force a policy update, resolving the issue described above. 
Note: that this may increase the CPU load on the CiliumAgent due to more frequent policy updates.