### PR TITLE
Fix duplicate lbipamConfig cell registration

### DIFF
--- a/operator/pkg/lbipam/cell.go
+++ b/operator/pkg/lbipam/cell.go
@@ -33,12 +33,12 @@ var Cell = cell.Module(
 	metrics.Metric(newMetrics),
 	// Register configuration flags
 	cell.Config(lbipamConfig{
-		EnableLBIPAM: true,
+		EnableLBIPAM:             true,
+		MinimumLBIPPoolsRequired: 1,
 	}),
 	cell.Config(SharedConfig{
 		DefaultLBServiceIPAM: DefaultLBClassLBIPAM,
 	}),
-	cell.Config(lbipamConfig{MinimumLBIPPoolsRequired: 1}),
 )
 
 type lbipamConfig struct {


### PR DESCRIPTION
Follow up https://github.com/cybozu-go/cilium/pull/7

Merge the two duplicate `cell.Config(lbipamConfig{...})` registrations into one to fix an operator startup panic caused by `enable-lb-ipam` and `minimum-lbip-pools-required` flags being declared twice.

```console
$ kubectl logs -n kube-system deploy/cilium-operator
panic: Failed to apply cell: 'enable-lb-ipam' declared twice: duplicate flag
        'minimum-lbip-pools-required' declared twice: duplicate flag
...
```